### PR TITLE
[FIX] updated NR for rest ratings

### DIFF
--- a/dcm_conversion/resources/behavior.py
+++ b/dcm_conversion/resources/behavior.py
@@ -353,8 +353,9 @@ def rest_ratings(rate_path, subj_raw, subid, sess):
     """
     # Read-in data, get stimulus and response
     df_rate = pd.read_csv(rate_path, na_values="None")
+    idx_stim = df_rate.index[df_rate["type"] == "RatingOnset"].tolist()
     idx_resp = df_rate.index[df_rate["type"] == "RatingResponse"].tolist()
-    rate_stim = df_rate.loc[idx_resp, "stimdescrip"].tolist()
+    rate_stim = df_rate.loc[idx_stim, "stimdescrip"].tolist()
     rate_resp = df_rate.loc[idx_resp, "stimtype"].tolist()
     rate_resp = ["88" if x != x else x for x in rate_resp]
 


### PR DESCRIPTION
Adjusted how resources.behavior.rest_ratings determines the stimulus, resulting in "Sadness : NR" rather than "NaN: 88" with a missing sadness field.