### PR TITLE
[dev] Handle Multiple Fieldmaps

### DIFF
--- a/dcm_conversion/bin/org_dcms.sh
+++ b/dcm_conversion/bin/org_dcms.sh
@@ -91,7 +91,8 @@ for i in *dcm; do
     fi
 
     # Setup output location, move dcm
-    prot_dir=${dcm_dir}/${prot_name//>/}
+    # Remove any ">"s protocol name with a single "_".
+    prot_dir=${dcm_dir}/${prot_name//+([>])/_}
     [ ! -d $prot_dir ] && mkdir -p $prot_dir
     echo -e "$c\t$prot_name <- $i"
     mv $i ${prot_dir}/$i

--- a/dcm_conversion/resources/unique_cases.py
+++ b/dcm_conversion/resources/unique_cases.py
@@ -69,3 +69,79 @@ def wash_issue(trial_types, task, sess, subid):
     if subid in issue_list:
         trial_types["wash"] = wash_update[task]
     return trial_types
+
+
+def fmap_issue(sess, subid, bold_list):
+    """Provide lists of func runs to associate with each fmap.
+
+    For various reasons, certain functional runs may need to
+    be paired with specific fmap acquisitions for certain participants.
+    This function provides those mappings.
+
+    Parameters
+    ----------
+    sess : str
+        BIDS session string
+    subid : str
+        Subject identifier
+    bold_list: list
+        List of bold images
+
+    Returns
+    -------
+    bold_lists : list
+        List of lists, where each sub-list contains the bold
+        images to be associated with a given fmap file.
+
+    """
+
+    subs_to_tend = {
+        "ER9998": {
+            "ses-day2": {
+                "fmap1": ["movies_01", "movies_02", "movies_03"],
+                "fmap2": [
+                    "movies_04",
+                    "movies_05",
+                    "movies_06",
+                    "movies_07",
+                    "movies_08",
+                    "rest_01",
+                ],
+            },
+            "ses-day3": {
+                "fmap1": [
+                    "scenarios_01",
+                    "scenarios_02",
+                    "scenarios_03",
+                    "scenarios_04",
+                    "scenarios_05",
+                    "rest_01",
+                ],
+                "fmap2": [
+                    "scenarios_06",
+                    "scenarios_07",
+                    "scenarios_08",
+                ],
+            },
+        },
+    }
+
+    if subid in subs_to_tend.keys():
+        # For each fmap, create a list of bold file names
+        # that matches the list of keys.
+        bold_lists = []
+        for fmap in sorted(subs_to_tend[subid][sess].keys()):
+            this_list = []
+            for bold_key in subs_to_tend[subid][sess][fmap]:
+                task, run = bold_key.split("_")
+                for bold_file in bold_list:
+                    if (f"task-{task}" in bold_file) and (
+                        f"run-{run}" in bold_file
+                    ):
+                        this_list.append(bold_file)
+            bold_lists.append(this_list)
+
+    else:
+        bold_lists = None
+
+    return bold_lists

--- a/dcm_conversion/resources/workflow.py
+++ b/dcm_conversion/resources/workflow.py
@@ -154,6 +154,7 @@ def _process_mri(source_path, raw_path, deriv_dir, subid, do_deface):
             nii_list, json_list = process.dcm2niix(
                 subj_source, subj_raw, subid, sess
             )
+
             t1_list = bidsify.bidsify_nii(
                 nii_list, json_list, subj_raw, subid, sess, task
             )


### PR DESCRIPTION
Updated bidsify process to handle multiple fieldmap images and properly distribute functional runs to their "intendedfor" json fields.

resources/bidsify.py:
(lines 58-61)
- Added link between new fieldmap dcm2niix file names and BIDS-formatted file names
(lines 140-179)
- Added check for number of fieldmap images in rawdata/[subj]/[ses]/fmap
- If number of fieldmaps is 1, add all bold images to "intendedfor"
- If number of fieldmaps is 2, split the bold images into two equal-sized lists and add one list to each fieldmap "intendedfor"
- If number of fieldmaps is greater than 2, raise an error, as this will require manual intervention

resources/unique_cases.py:
(lines 74-147)
- Added fmap_issue() for handling cases where a participant's bold images cannot simply be evenly distributed between existing fieldmaps
- If subject ID is in subs_to_tend, create two lists of bold image files based on the subs_to_tend dictionary and return a list of these lists
- If subject ID is not in subs_to_tend, return None

bin/org_dcms.sh:
(lines 94-95)
- Changed protocol name management to replace all groups of occurrences of ">" with a single "_"